### PR TITLE
Implement `ignore-not-found` option.

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -29,11 +29,12 @@ import (
 var (
 	ErrNotfoundValueConfig = errors.New("not found value config")
 	ErrValueIsEmpty        = errors.New("value is empty")
+	ErrInvalidJSON         = errors.New("invalid json string")
 )
 
 // Client is the external stores client.
 type Client interface {
-	GetValues(ctx context.Context, ignoreEmpty bool) (Values, error)
+	GetValues(ctx context.Context, ignoreNotFound bool) (Values, error)
 }
 
 // New returns a new Client.
@@ -63,7 +64,7 @@ func (v Values) SetValue(cfg config.Value, value *string) error {
 	if cfg.GetIsJSON() {
 		val = make(map[string]any)
 		if err := json.Unmarshal([]byte(*value), &val); err != nil {
-			return fmt.Errorf("%w: invalid json string", err)
+			return fmt.Errorf("%w: %w", ErrInvalidJSON, err)
 		}
 	} else {
 		val = *value

--- a/internal/cmd/template.go
+++ b/internal/cmd/template.go
@@ -38,6 +38,7 @@ const example = `  # specify single file.
 
 func newTemplateCommand() *cobra.Command {
 	var configFile string
+	var ignoreNotFound bool
 
 	cmd := cobra.Command{
 		Use:     "template <file>",
@@ -54,7 +55,7 @@ func newTemplateCommand() *cobra.Command {
 				return err
 			}
 
-			eng, err := engine.New(cfg)
+			eng, err := engine.New(cfg, engine.IgnoreNotFound(ignoreNotFound))
 			if err != nil {
 				return err
 			}
@@ -70,6 +71,7 @@ func newTemplateCommand() *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVarP(&configFile, "config", "c", config.DefaultConfigFilename, "specify config file.")
+	f.BoolVar(&ignoreNotFound, "ignore-not-found", false, "ignore values are not found in the external store.")
 
 	return &cmd
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -56,7 +56,7 @@ func New(cfg *config.Config, option ...Option) (Engine, error) {
 }
 
 func (e engine) Render(ctx context.Context, text string, dest io.Writer) error {
-	values, err := e.client.GetValues(ctx, e.option.IgnoreEmpty)
+	values, err := e.client.GetValues(ctx, e.option.IgnoreNotFound)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/options.go
+++ b/pkg/engine/options.go
@@ -19,17 +19,17 @@ package engine
 // Option is configurable Engine behavior.
 type Option func(*opts)
 
-// IgnoreEmpty ignores empty value from external store.
-func IgnoreEmpty() Option {
+// IgnoreNotFound ignores values are not found in the external store.
+func IgnoreNotFound(b bool) Option {
 	return func(o *opts) {
-		o.IgnoreEmpty = true
+		o.IgnoreNotFound = b
 	}
 }
 
 type opts struct {
-	IgnoreEmpty bool
+	IgnoreNotFound bool
 }
 
 var defaultOpts = &opts{
-	IgnoreEmpty: false,
+	IgnoreNotFound: false,
 }


### PR DESCRIPTION
### Overview

Fix #64. I implement a `ignore not found` option.

This option can be controlled with the `engine.IgnoreNotFound()` function, and can be set via the `--ignore-not-found` command line argument.

### Verification

I am verifying that running the example without executing the setup changes the results.

```sh
# before
❯ ./dist/ysr_darwin_arm64/ysr template -c ./example/yashiro.yaml ./example/*.tmpl                   
operation error SSM: GetParameter, https response error StatusCode: 400, RequestID: be67bca1-6ee5-47bf-8a97-143350ead87a, ParameterNotFound:

# after
❯ ./dist/ysr_darwin_arm64/ysr template -c ./example/yashiro.yaml ./example/*.tmpl --ignore-not-found
---
apiVersion: v1
kind: Secret
metadata:
  name: example
  labels:
    app: example
data:
  db_password: template: yashiro:9:18: executing "yashiro" at <.exampleSecure>: map has no entry for key "exampleSecure"
```