### PR TITLE
Wrap package errors

### DIFF
--- a/internal/client/aws.go
+++ b/internal/client/aws.go
@@ -85,7 +85,7 @@ func (c awsClient) GetValues(ctx context.Context, ignoreNotFound bool) (values.V
 			if ignoreNotFound && errors.As(err, &notFoundErr) {
 				continue
 			}
-			return nil, err
+			return nil, gettingValueError(v.Name, err)
 		}
 
 		if err := values.SetValue(v, output.Parameter.Value); err != nil {
@@ -103,7 +103,7 @@ func (c awsClient) GetValues(ctx context.Context, ignoreNotFound bool) (values.V
 			if ignoreNotFound && errors.As(err, &notFoundErr) {
 				continue
 			}
-			return nil, err
+			return nil, gettingValueError(v.Name, err)
 		}
 
 		if err := values.SetValue(v, output.SecretString); err != nil {

--- a/internal/client/cache/cache.go
+++ b/internal/client/cache/cache.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	ErrInvalidCacheType = errors.New("invalid cache type")
+	ErrCacheProcessing  = errors.New("cache processing error")
 )
 
 type Cache interface {
@@ -57,4 +58,12 @@ func New(cfg config.CacheConfig, options ...Option) (Cache, error) {
 
 func keyToHex(key string) string {
 	return hex.EncodeToString([]byte(key))
+}
+
+func cacheProcessingError(msg string, err error) error {
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", ErrCacheProcessing, msg, err)
+	}
+
+	return fmt.Errorf("%w: %s", ErrCacheProcessing, msg)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/dwango/yashiro/internal/values"
 	"github.com/dwango/yashiro/pkg/config"
@@ -27,6 +28,7 @@ import (
 // Define errors
 var (
 	ErrNotfoundValueConfig = errors.New("not found value config")
+	ErrGettingValue        = errors.New("failed to get value")
 )
 
 // Client is the external stores client.
@@ -51,4 +53,8 @@ func New(cfg *config.Config) (Client, error) {
 	}
 
 	return client, nil
+}
+
+func gettingValueError(name string, err error) error {
+	return fmt.Errorf("%w: name='%s': %w", ErrGettingValue, name, err)
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2024 DWANGO Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errors
+
+import (
+	"errors"
+
+	"github.com/dwango/yashiro/internal/client/cache"
+	"github.com/dwango/yashiro/pkg/engine"
+)
+
+// IsCacheProcessingError returns true if the error is a cache processing error.
+func IsCacheProcessingError(err error) bool {
+	return errors.Is(err, cache.ErrCacheProcessing)
+}
+
+// IsRenderingError returns true if the error is a rendering error.
+func IsRenderingError(err error) bool {
+	return errors.Is(err, engine.ErrRendering)
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2024 DWANGO Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dwango/yashiro/internal/client/cache"
+	"github.com/dwango/yashiro/pkg/engine"
+)
+
+func TestIsCacheProcessingError(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "true",
+			args: args{
+				err: fmt.Errorf("test: %w", cache.ErrCacheProcessing),
+			},
+			want: true,
+		},
+		{
+			name: "false",
+			args: args{
+				err: fmt.Errorf("test: %w", errors.New("different error")),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCacheProcessingError(tt.args.err); got != tt.want {
+				t.Errorf("IsCacheProcessingError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRenderingError(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "true",
+			args: args{
+				err: fmt.Errorf("test: %w", engine.ErrRendering),
+			},
+			want: true,
+		},
+		{
+			name: "false",
+			args: args{
+				err: fmt.Errorf("test: %w", errors.New("different error")),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRenderingError(tt.args.err); got != tt.want {
+				t.Errorf("IsRenderingError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Overview

Close #63 

I wrapped package errors. So, its name is now displayed in the error message when a value cannot be retrieved from an external store.
In addition, functions to identify some errors were added.

#### Vilification

```txt
failed to get value: name='/yashiro/exampl': operation error SSM: GetParameter, https response error StatusCode: 400, RequestID: a3fe5cb1-3fd6-49aa-8696-9cb67aabcc3b, ParameterNotFound:
```